### PR TITLE
[FIX] patch for Samba write bug from Arch repos

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -190,6 +190,7 @@ gint file_save_real(GtkWidget *view, FileInfo *fi)
 	gtk_text_buffer_get_start_iter(buffer, &start);
 	gtk_text_buffer_get_end_iter(buffer, &end);	
 	str = gtk_text_buffer_get_text(buffer, &start, &end, FALSE);
+  gtk_text_buffer_set_modified(buffer, FALSE);
 	
 	switch (fi->lineend) {
 	case CR:
@@ -229,7 +230,6 @@ gint file_save_real(GtkWidget *view, FileInfo *fi)
 		return -1;
 	}
 	
-	gtk_text_buffer_set_modified(buffer, FALSE);
 	fclose(fp);
 	g_free(cstr);
 	

--- a/src/file.c
+++ b/src/file.c
@@ -190,8 +190,7 @@ gint file_save_real(GtkWidget *view, FileInfo *fi)
 	gtk_text_buffer_get_start_iter(buffer, &start);
 	gtk_text_buffer_get_end_iter(buffer, &end);	
 	str = gtk_text_buffer_get_text(buffer, &start, &end, FALSE);
-  gtk_text_buffer_set_modified(buffer, FALSE);
-	
+  
 	switch (fi->lineend) {
 	case CR:
 		convert_line_ending(&str, CR);
@@ -231,6 +230,7 @@ gint file_save_real(GtkWidget *view, FileInfo *fi)
 	}
 	
 	fclose(fp);
+  gtk_text_buffer_set_modified(buffer, FALSE);
 	g_free(cstr);
 	
 	return 0;

--- a/src/file.c
+++ b/src/file.c
@@ -226,6 +226,7 @@ gint file_save_real(GtkWidget *view, FileInfo *fi)
 	if (fwrite(cstr, 1, wbytes, fp) != wbytes) {
 		run_dialog_message(gtk_widget_get_toplevel(view),
 			GTK_MESSAGE_ERROR, _("Can't write file"));
+    fclose(fp);
 		return -1;
 	}
 	


### PR DESCRIPTION
This patch was added to the Arch package for Leafpad 4 years ago and it fixes a serious bug that removed the content of files on samba shared files.

See this ticket on Arch bug tracker for more info.
https://bugs.archlinux.org/task/44681

>When editing text file on samba shares, after saving AND exiting leafpad, complete text (you see that when opening again, with leafpad or other txt editor) is wiped out. I rarely use leafpad over LAN files, and can roughly say that last year 10/2014, there was no this bug.