### PR TITLE
Fix french translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -111,7 +111,7 @@ msgstr "/_Options"
 
 #: ../src/menu.c:93
 msgid "/Options/_Font..."
-msgstr "/Options/_Fonte..."
+msgstr "/Options/_Police..."
 
 #: ../src/menu.c:95
 msgid "/Options/_Word Wrap"
@@ -149,7 +149,7 @@ msgstr "Enregistrer les changements pour '%s' ?"
 
 #: ../src/font.c:44
 msgid "Font"
-msgstr "Fonte"
+msgstr "Police"
 
 #: ../src/selector.c:99
 #, c-format


### PR DESCRIPTION
"Font" is translated "Police", not "Fonte".

~~When translating "Font" into french you have two choices: either you keep the english word "Font", or, better, you use the french word for that which is "Police", but saying "Fonte" doesn't make sense as it's a whole other thing that has nothing to do with it.~~

EDIT: Actually it seems like "Fonte" is also correct BUT I've never seen it anywhere, on any software, and "Police" is the word widely used for this.