### PR TITLE
Add man page

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,7 @@
 bin_PROGRAMS = leafpad
 
+man_MANS = leafpad.1
+
 INCLUDES = -DICONDIR=\"$(datadir)/pixmaps\"
 
 leafpad_SOURCES = \

--- a/src/leafpad.1
+++ b/src/leafpad.1
@@ -1,0 +1,89 @@
+.TH "leafpad" 1 "0.8.18.1" Linux "User Manuals"
+.SH Name
+leafpad - GTK+ based simple text editor
+.SH Synopsis
+.B leafpad [OPTIONS...] [filename]
+.SH Description
+Leafpad is a simple GTK+ text editor that emphasizes simplicity.
+As development focuses on keeping weight down to a minimum, only
+the most essential features are implemented in the editor.
+Leafpad is simple to use, is easily compiled, requires few libraries,
+and starts up quickly.
+Currently Leafpad has the following features:
+.P
+.RS
+.TP
+Codeset option (Some OpenI18N registered)
+.TP
+Auto codeset detection (UTF-8 and some codesets)
+.TP
+Unlimitted Undo/Redo
+.TP
+Auto/Multi-line Indent
+.TP
+Display line numbers
+.TP
+Drag and Drop
+.TP
+Printing
+.RE
+.SH Options
+.TP
+.B -h, --help
+Show help options
+.TP
+.B -help-all
+Show all help options
+.TP
+.B --help-gtk
+Show GTK+ Options
+.TP
+.B --class=CLASS
+Program class as used by the window manager
+.TP
+.B --name=NAME
+Program name as used by the window manager
+.TP
+.B --screen=SCREEN
+X screen to use
+.TP
+.B --gdk-debug=FLAGS
+GDK debugging flags to set
+.TP
+.B --gdk-no-debug=FLAGS
+GDK debugging flags to unset
+.TP
+.B --sync
+Make X calls synchronous
+.TP
+.B --gtk-module=MODULES
+Load additional GTK+ modules
+.TP
+.B --g-fatal-warnings
+Make all warnings fatal
+.TP
+.B --gtk-debug=FLAGS
+GTK+ debugging flags to set
+.TP
+.B --gtk-no-debug=FLAGS
+GTK+ debugging flags to unset
+.TP
+.B --codeset=CODESET
+Set codeset to open file
+.TP
+.B --tab-width=WIDTH
+Set tab width
+.TP
+.B --jump=LINENUM
+Jump to specified line
+.TP
+.B --version
+Show version number
+.TP
+.B --display=DISPLAY
+X display to use
+.SH Author
+Tarot Osuji
+.SH Copyright
+Copyright (c) 2004-2010
+


### PR DESCRIPTION
Run:
autoreconf --install
Then .configure, make, make install

The make install will now include the leafpad.1 man page.

The man page has Name, Synopsis, Description, Options, Author, and Copyright sections and uses only standard formatting for man pages.
The man page has the --help-all text in the Options section.