### PR TITLE
fix format-security error from gcc

### DIFF
--- a/src/dialog.c
+++ b/src/dialog.c
@@ -36,7 +36,7 @@ void run_dialog_message(GtkWidget *window,
 		GTK_DIALOG_DESTROY_WITH_PARENT,
 		type,
 		GTK_BUTTONS_NONE,
-		str);
+		"%s", str);
 	gtk_window_set_resizable(GTK_WINDOW(dialog), FALSE);
 	gtk_dialog_add_buttons(GTK_DIALOG(dialog),
 		GTK_STOCK_OK, GTK_RESPONSE_CANCEL, NULL);
@@ -61,7 +61,7 @@ GtkWidget *create_dialog_message_question(GtkWidget *window, gchar *message, ...
 		GTK_DIALOG_DESTROY_WITH_PARENT,
 		GTK_MESSAGE_QUESTION,
 		GTK_BUTTONS_NONE,
-		str);
+		"%s", str);
 	gtk_window_set_resizable(GTK_WINDOW(dialog), FALSE);
 	gtk_dialog_add_buttons(GTK_DIALOG(dialog),
 		GTK_STOCK_NO, GTK_RESPONSE_NO,

--- a/src/gtkprint.c
+++ b/src/gtkprint.c
@@ -165,7 +165,7 @@ static void create_error_dialog(GtkTextView *text_view, gchar *message)
 		GTK_DIALOG_DESTROY_WITH_PARENT,
 		GTK_MESSAGE_ERROR,
 		GTK_BUTTONS_NONE,
-		message);
+		"%s", message);
 	gtk_window_set_resizable(GTK_WINDOW(dialog), FALSE);
 	gtk_dialog_add_buttons(GTK_DIALOG(dialog),
 		GTK_STOCK_OK, GTK_RESPONSE_CANCEL, NULL);


### PR DESCRIPTION
Building with `-Werror=format-security` causes several of these errors:

error: format not a string literal and no format arguments [-Werror=format-security]

Let's fix by giving a proper format string.