### PR TITLE
MinGW patch for Windows build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,19 @@ AM_PROG_CC_C_O
 
 PKG_CHECK_MODULES(GTK, gtk+-2.0)
 
+AC_MSG_CHECKING([for Win32])
+case "$host" in
+*-mingw*)
+    os_win32=yes
+    ;;
+*)  os_win32=no
+    ;;
+esac
+
+AC_MSG_RESULT([$os_win32])
+AM_CONDITIONAL(OS_WIN32, [test $os_win32 = yes])
+AC_SUBST(SOEXT)
+
 AC_ARG_ENABLE(chooser,
 	AC_HELP_STRING(--disable-chooser, [force to use GtkFileSelector]))
 if test "$enable_chooser" != "no"; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,3 +28,6 @@ leafpad_SOURCES = \
 leafpad_LDADD    = $(GTK_LIBS) $(GNOMEPRINT_LIBS) $(INTLLIBS)
 leafpad_CFLAGS   = $(GTK_CFLAGS) $(GNOMEPRINT_CFLAGS)
 leafpad_CPPFLAGS = -DICONDIR=\"$(datadir)/pixmaps\"
+if OS_WIN32
+leafpad_LDFLAGS = -mwindows
+endif

--- a/src/file.c
+++ b/src/file.c
@@ -31,8 +31,12 @@
 gboolean check_file_writable(gchar *filename)
 {
 	FILE *fp;
-	
+
+#ifdef __MINGW32__	
+	if ((fp = fopen(filename, "a+b")) != NULL) {
+#else
 	if ((fp = fopen(filename, "a")) != NULL) {
+#endif
 		fclose(fp);
 		return TRUE;
 	}
@@ -216,8 +220,12 @@ gint file_save_real(GtkWidget *view, FileInfo *fi)
 		g_error_free(err);
 		return -1;
 	}
-	
+
+#ifdef __MINGW32__	
+	fp = fopen(fi->filename, "wb");
+#else
 	fp = fopen(fi->filename, "w");
+#endif
 	if (!fp) {
 		run_dialog_message(gtk_widget_get_toplevel(view),
 			GTK_MESSAGE_ERROR, _("Can't open file to write"));

--- a/src/gtkprint.c
+++ b/src/gtkprint.c
@@ -139,13 +139,21 @@ static GtkPrintOperation *create_print_operation(GtkTextView *text_view)
 	
 	if (settings)
 		gtk_print_operation_set_print_settings(op, settings);
+
+#ifdef G_OS_WIN32 /* Apply gitlab gtk #4c399695 fix WIN32 printing */ 
+  GtkUnit units = GTK_UNIT_POINTS;
+  gtk_print_operation_set_use_full_page (op, FALSE);
+  gtk_print_operation_set_unit (op, units);
+#else
+  GtkUnit units = GTK_UNIT_MM;
+#endif
 	
 	if (!page_setup) {
 		page_setup = gtk_page_setup_new();
-		gtk_page_setup_set_top_margin(page_setup, 25.0, GTK_UNIT_MM);
-		gtk_page_setup_set_bottom_margin(page_setup, 20.0, GTK_UNIT_MM);
-		gtk_page_setup_set_left_margin(page_setup, 20.0, GTK_UNIT_MM);
-		gtk_page_setup_set_right_margin(page_setup, 20.0, GTK_UNIT_MM);
+		gtk_page_setup_set_top_margin(page_setup, 25.0, units);
+		gtk_page_setup_set_bottom_margin(page_setup, 20.0, units);
+		gtk_page_setup_set_left_margin(page_setup, 20.0, units);
+		gtk_page_setup_set_right_margin(page_setup, 20.0, units);
 	}
 	gtk_print_operation_set_default_page_setup(op, page_setup);
 	


### PR DESCRIPTION
Fix Win32 printing with gitlab gtk #4c399695
Use binary I/O mode
WIN32 Link with -mwindows